### PR TITLE
Fix Oodle0 and various trivial changes

### DIFF
--- a/libopengrn/CMakeLists.txt
+++ b/libopengrn/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
         set(LIB_VARIANT STATIC)
 endif()
 
-add_library(opengrn STATIC ${SOURCE_FILES} ${HEADER_FILES})
+add_library(opengrn ${LIB_VARIANT} ${SOURCE_FILES} ${HEADER_FILES})
 
 target_include_directories(opengrn PUBLIC .)
 

--- a/libopengrn/compression.c
+++ b/libopengrn/compression.c
@@ -44,21 +44,21 @@ bool Compression_UnOodle1(uint8_t* compressedData,
                           uint32_t oodleStop2,
                           bool endianessMismatch,
                           bool isOodle0) {
-    if(compressedLength == 0) {
-        return true;
-    }
-
     TParameter parameters[3];
 
-    memset(parameters, 0, sizeof(parameters));
-    memcpy(parameters, compressedData, sizeof(parameters));
+    if(compressedLength < sizeof(parameters)) {
+        return true;
+    }
 
     if (endianessMismatch) {
         if (isOodle0)
             Platform_Swap1(compressedData, compressedLength);
         else
-            Platform_Swap1((uint8_t*)parameters, sizeof(parameters));
+            Platform_Swap1(compressedData, sizeof(parameters));
     }
+
+    memset(parameters, 0, sizeof(parameters));
+    memcpy(parameters, compressedData, sizeof(parameters));
 
     TDecoder decoder;
     Decoder_Init(&decoder, compressedData + sizeof(parameters));

--- a/libopengrn/compression.c
+++ b/libopengrn/compression.c
@@ -33,6 +33,7 @@ int Compression_GetExtraLen(uint32_t nType)
     @param decompressedLength length of the decompressed data
     @param oodleStop1 first stop byte of oodle
     @param oodleStop2 second stop byte of oodle
+    @param isOodle0 if the compression codec is the older oodle compression variant
     @return true if the decompression succeeded, otherwise false
 */
 bool Compression_UnOodle1(uint8_t* compressedData,
@@ -41,7 +42,8 @@ bool Compression_UnOodle1(uint8_t* compressedData,
                           uint32_t decompressedLength,
                           uint32_t oodleStop1,
                           uint32_t oodleStop2,
-                          bool endianessMismatch) {
+                          bool endianessMismatch,
+                          bool isOodle0) {
     if(compressedLength == 0) {
         return true;
     }
@@ -51,8 +53,12 @@ bool Compression_UnOodle1(uint8_t* compressedData,
     memset(parameters, 0, sizeof(parameters));
     memcpy(parameters, compressedData, sizeof(parameters));
 
-    if (endianessMismatch)
-        Platform_Swap1((uint8_t*)parameters, sizeof(parameters));
+    if (endianessMismatch) {
+        if (isOodle0)
+            Platform_Swap1(compressedData, compressedLength);
+        else
+            Platform_Swap1((uint8_t*)parameters, sizeof(parameters));
+    }
 
     TDecoder decoder;
     Decoder_Init(&decoder, compressedData + sizeof(parameters));

--- a/libopengrn/compression.h
+++ b/libopengrn/compression.h
@@ -42,6 +42,7 @@ extern int Compression_GetExtraLen(uint32_t nType);
 	@param oodleStop1 first stop byte of oodle
 	@param oodleStop2 second stop byte of oodle
 	@param endianessMismatch if the file has a different endianess
+	@param isOodle0 if the compression codec is the older oodle compression variant
 	@return true if the decompression succeeded, otherwise false
 */
 extern bool Compression_UnOodle1(uint8_t* compressedData,
@@ -50,4 +51,5 @@ extern bool Compression_UnOodle1(uint8_t* compressedData,
                                            uint32_t decompressedLength,
                                            uint32_t oodleStop1,
                                            uint32_t oodleStop2,
-	                                       bool endianessMismatch);
+                                           bool endianessMismatch,
+                                           bool isOodle0);

--- a/libopengrn/gr2_read.c
+++ b/libopengrn/gr2_read.c
@@ -276,14 +276,9 @@ OG_DLLAPI bool Gr2_Load(const uint8_t* data, size_t len, TGr2* gr2)
 
 			switch (sector.compressType)
 			{
-#if 0
-			case COMPRESSION_TYPE_OODLE0:
-				success = Compression_UnOodle0(pCompData, sct.compressedLen, pDecompData, cnt.info.decompressLen);
-				break;
-#endif
 			case COMPRESSION_TYPE_OODLE0:
 			case COMPRESSION_TYPE_OODLE1:
-				success = Compression_UnOodle1(pComp, sector.compressedLen, pDecomp, sector.decompressLen, sector.oodleStop0, sector.oodleStop1, gr2->mismatchEndianness);
+				success = Compression_UnOodle1(pComp, sector.compressedLen, pDecomp, sector.decompressLen, sector.oodleStop0, sector.oodleStop1, gr2->mismatchEndianness, sector.compressType == COMPRESSION_TYPE_OODLE0);
 				break;
 #if 0
 			case COMPRESSION_TYPE_BITKNIT1:
@@ -339,7 +334,7 @@ OG_DLLAPI bool Gr2_Load(const uint8_t* data, size_t len, TGr2* gr2)
 
 		for (k = 0; k < sector.marshallSize; k++)
 		{
-			pos = sector.marshallOffset + (k * sizeof(TFixUpData));
+			pos = sector.marshallOffset + (k * sizeof(TMarshallData));
 
 			if (pos > len)
 			{


### PR DESCRIPTION
Does what it says on the title. 

- Adds Oodle0 (identical to Oodle1, with a diff swap operation)
- Fixes OOB copy if buffer is > 0 but < 36 bytes
- Fixes offset calculation for `TMarshallData`
- Fixes CMake not respecting `OPENGRN_STATIC`